### PR TITLE
Parent links won't necessarily trigger on mouseover

### DIFF
--- a/prefetch.js
+++ b/prefetch.js
@@ -163,7 +163,7 @@
 
     function attachListener(el, type){
       el.addEventListener(type, function (e){
-        if(e.target.matches('a')){
+        if(e.target.matches('a') || getLinkTarget(e.target)){
           switch(type){
             case 'touchstart': touchstart(e); break;
             case 'mousedown':  mousedown(e);  break;
@@ -173,6 +173,6 @@
       });
     }
   }
-    
+
   return new Prefetch().init();
 });


### PR DESCRIPTION
There are scenarios where the target element won't be the link, it will be a child of the link. (I experienced this with a link enclosing an image and a teaser paragraph.)

This should fix that. If the target is not a link, it will look up the tree to see if there are any links there. You already have this code to ascend the tree to find the parent link, but it can't be used for that purpose because of the issue I detailed above. So, now it allows us to find out if a parent is a link, and then it'll also be used to grab that parent.
